### PR TITLE
Run Jekyll localy via docker

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,11 @@
+version: '3'
+
+services:
+  jeykll-serer:
+    image: starefossen/github-pages
+    container_name: brighton-alt-net-jekyll-server
+    volumes:
+      - ./:/usr/src/app
+    ports:
+      - 4000:4000
+           


### PR DESCRIPTION
Hi Mike

This small change adds a 'docker-compose' file which spins up a Jekyll server and binds it to the local folder. I found this easier than installing Ruby and all the Bundler tool chain 😴 

Start it with `docker-compose up` and stop is with `docker-compose down`