### PR TITLE
Correct navbar for mobile. fixes #5

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -17,10 +17,18 @@
 
     <nav class="navbar navbar-expand-md navbar-dark fixed-top bg-dark">
       <a class="navbar-brand" href="/">Brighton ALT NET</a>
-      <div class="collapse navbar-collapse">
-        <ul class="navbar-nav">
-          <li class="nav-item"> <a class="nav-link" href="/directory.html">Directory</a></li>
-          <li class="nav-item"> <a class="nav-link" href="/meetings.html">Meetings</a></li>
+    <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarCollapse" aria-controls="navbarCollapse"
+      aria-expanded="false" aria-label="Toggle navigation">
+      <span class="navbar-toggler-icon"></span>
+    </button>
+    <div class="collapse navbar-collapse" id="navbarCollapse">
+      <ul class="navbar-nav mr-auto">
+        <li class="nav-item">
+          <a class="nav-link" href="/directory.html">Directory</a>
+        </li>
+        <li class="nav-item">
+          <a class="nav-link" href="/meetings.html">Meetings</a>
+        </li>
         </ul>
       </div>
     </nav>
@@ -86,4 +94,5 @@
       $(".next-meeting-date").html(getNextMeetingDate(new Date()));
     </script>
   </body>
+
 </html>


### PR DESCRIPTION
Before this fix the navigation was hidden on small screen resolutions due to bootstrap adaptive layout. This fixes this by adding a button to show the collapsed navigation